### PR TITLE
implemented @Named annotation to solved multiple modules that provide instances of the same type.

### DIFF
--- a/app/src/main/java/com/examen/dagger2_kotlin/UserRegistrationService.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/UserRegistrationService.kt
@@ -1,10 +1,11 @@
 package com.examen.dagger2_kotlin
 
 import javax.inject.Inject
+import javax.inject.Named
 
 
 class UserRegistrationService @Inject constructor(
-    private val userRepository:UserRepository,
+   @Named("SQLRepository") private val userRepository:UserRepository,
     private  val notificationServices: NotificationServices
   ) {
 

--- a/app/src/main/java/com/examen/dagger2_kotlin/UserRepository.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/UserRepository.kt
@@ -9,7 +9,7 @@ interface UserRepository {
 
 class SQLRepository : UserRepository {
     override fun saveUser(email: String, password: String) {
-        println("Saving user to database: $email, $password")
+        Log.d("SQLRepository", "saveUser:  $email, $password")
     }
 }
 

--- a/app/src/main/java/com/examen/dagger2_kotlin/UserRepositoryModule.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/UserRepositoryModule.kt
@@ -3,14 +3,16 @@ package com.examen.dagger2_kotlin
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import javax.inject.Named
 
 @Module()
  class UserRepositoryModule {
 
-   /* @Provides
+     @Named("SQLRepository")
+    @Provides
     fun provideSqlRepository():UserRepository{
         return SQLRepository()
-    }*/
+    }
 
 
     @Provides


### PR DESCRIPTION
1. @Module UserRepositoryModule class proivde same type of object into component and get confused which one pick so that throwing duplicate dependency at the compiler time.
2.  Dagger 2 may encounter a situation where it doesn't know which instance to use. This is known as a "binding ambiguity" or "duplicate binding" problem.
3. To solved this issue we used a @Named annotation when consumer asked dependency to component class so at time component provide the specific dependency to consumer using @Named annotation.
4. In Dagger 2, the @Named annotation is checked by the compiler and the Dagger processor at compile-time.