### PR TITLE
implemented a @Qualifier in this code

### DIFF
--- a/app/src/main/java/com/examen/dagger2_kotlin/MessageQualifier.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/MessageQualifier.kt
@@ -1,0 +1,8 @@
+package com.examen.dagger2_kotlin
+
+import javax.inject.Qualifier
+
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MessageQualifier()

--- a/app/src/main/java/com/examen/dagger2_kotlin/NotificationServices.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/NotificationServices.kt
@@ -13,7 +13,7 @@ class EmailService @Inject constructor(): NotificationServices{
     }
 }
 
-class MessageService : NotificationServices{
+class MessageService @Inject constructor(): NotificationServices{
     override fun sent(to: String, from: String, body: String) {
         Log.d("MessageService", "sent: ")
     }

--- a/app/src/main/java/com/examen/dagger2_kotlin/NotificationServicesModule.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/NotificationServicesModule.kt
@@ -2,7 +2,7 @@ package com.examen.dagger2_kotlin
 
 import dagger.Module
 import dagger.Provides
-
+// provider - producer provide the dependency object to consumer through component
 @Module()
 class NotificationServicesModule {
 
@@ -10,4 +10,12 @@ class NotificationServicesModule {
     fun provideEmailService ():NotificationServices{
         return  EmailService()
     }
+
+    @MessageQualifier
+    @Provides
+    fun provideMessageServies(): NotificationServices{
+        return MessageService()
+    }
+    // @MessageQualifier In Dagger 2, the @Qualifier annotation is used to solve the problem of binding ambiguity or duplicate binding.
+    /*When you have multiple modules that provide instances of the same type, Dagger 2 may encounter a situation where it doesn't know which instance to use. This is known as a binding ambiguity or duplicate binding problem.*/
 }

--- a/app/src/main/java/com/examen/dagger2_kotlin/UserRegistrationService.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/UserRegistrationService.kt
@@ -6,7 +6,7 @@ import javax.inject.Named
 
 class UserRegistrationService @Inject constructor(
    @Named("SQLRepository") private val userRepository:UserRepository,
-    private  val notificationServices: NotificationServices
+   @MessageQualifier private  val notificationServices: NotificationServices
   ) {
 
     fun registerUser(email:String,password:String){

--- a/app/src/main/java/com/examen/dagger2_kotlin/UserRepositoryModule.kt
+++ b/app/src/main/java/com/examen/dagger2_kotlin/UserRepositoryModule.kt
@@ -1,6 +1,6 @@
 package com.examen.dagger2_kotlin
 
-import dagger.Binds
+
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named


### PR DESCRIPTION
1.In Dagger 2, the @Qualifier annotation is used to solve the problem of binding ambiguity or duplicate binding.
2. When you have multiple modules that provide instances of the same type, Dagger 2 may encounter a situation where it doesn't know which instance to use. This is known as a binding ambiguity or duplicate binding problem.